### PR TITLE
Add support for HOCON configuration format

### DIFF
--- a/konfy-hocon/src/main/kotlin/tanvd/konfy/hocon/HoconProvider.kt
+++ b/konfy-hocon/src/main/kotlin/tanvd/konfy/hocon/HoconProvider.kt
@@ -1,0 +1,15 @@
+package tanvd.konfy.hocon
+
+import com.typesafe.config.Config
+import tanvd.konfy.provider.ConfigProvider
+import tanvd.konfy.conversion.ConversionService
+import java.lang.reflect.Type
+
+class HoconProvider(private val config: Config, private val convert: (String, Type) -> Any? = ConversionService::convert) : ConfigProvider() {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <N : Any> fetch(key: String, type: Type): N? {
+        val value = config.getString(key) ?: return null
+        return convert(value, type) as N?
+    }
+}

--- a/konfy-hocon/src/main/kotlin/tanvd/konfy/hocon/utils/Conversion.kt
+++ b/konfy-hocon/src/main/kotlin/tanvd/konfy/hocon/utils/Conversion.kt
@@ -1,0 +1,15 @@
+package tanvd.konfy.hocon.utils
+
+import com.typesafe.config.ConfigValue
+import tanvd.konfy.conversion.ConversionService
+import java.lang.reflect.Type
+
+object Conversion {
+    fun convert(value: ConfigValue, type: Type): Any? {
+        return when (value.valueType()) {
+            ConfigValueType.OBJECT -> value.unwrapped()
+            ConfigValueType.LIST -> (value.unwrapped() as List<*>).map { ConversionService.convert(it.toString(), type) }
+            else -> ConversionService.convert(value.unwrapped().toString(), type)
+        }
+    }
+}

--- a/konfy-hocon/src/test/kotlin/tanvd/konfy/hocon/HoconProviderTest.kt
+++ b/konfy-hocon/src/test/kotlin/tanvd/konfy/hocon/HoconProviderTest.kt
@@ -1,0 +1,47 @@
+package tanvd.konfy.hocon
+
+import com.typesafe.config.ConfigFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class HoconProviderTest {
+    private val configProvider
+        get() = HoconProvider(ConfigFactory.parseFile(File("src/test/resources/config.conf")))
+
+    @Test
+    fun get_keyExists_gotValue() {
+        val value: String = configProvider.get("first_test")
+        assertThat(value).isEqualTo("test-pass")
+    }
+
+    @Test
+    fun tryGet_keyDoesNotExist_noValue() {
+        val value: String? = configProvider.tryGet("third_test")
+        assertThat(value).isNull()
+    }
+
+    @Test
+    fun get_keyInTable_gotValue() {
+        val value: String = configProvider.get("section.fourth_test")
+        assertThat(value).isEqualTo("test-pass")
+    }
+
+    @Test
+    fun get_arrayValue_gotValue() {
+        val value: Array<String> = configProvider.get("section.arena-letters")
+        assertThat(value).containsAll(listOf("All", "King", "Edwards", "Horses", "Can", "Move", "Bloody", "Fast"))
+    }
+
+    @Test
+    fun get_nestedArrayValue_gotValue() {
+        val value: Array<Array<String>> = configProvider.get("section.array-in-array")
+        assertThat(value).isDeepEqualTo(arrayOf(arrayOf("123"), arrayOf("456")))
+    }
+
+    @Test
+    fun get_nestedTable_gotValue() {
+        val value: String = configProvider.get("section.nested.best-bike-ever")
+        assertThat(value).isEqualTo("KTM Duke 390")
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,4 +6,4 @@ include(":konfy-keepass")
 include(":konfy-ssm")
 include(":konfy-kara")
 include(":konfy-k8s")
-
+include(":konfy-hocon")


### PR DESCRIPTION
Add support for HOCON configuration format and update necessary gradle files

* **Gradle Configuration**
  - Add `include(":konfy-hocon")` to `settings.gradle.kts`

* **HOCON Provider Implementation**
  - Create `HoconProvider.kt` in `konfy-hocon/src/main/kotlin/tanvd/konfy/hocon/`
  - Implement `HoconProvider` class extending `ConfigProvider`
  - Add constructor that takes a `Config` object
  - Implement `fetch` method to retrieve values from the HOCON config

* **HOCON Conversion Utilities**
  - Create `Conversion.kt` in `konfy-hocon/src/main/kotlin/tanvd/konfy/hocon/utils/`
  - Implement function to convert HOCON values to the desired type

* **Testing**
  - Create `HoconProviderTest.kt` in `konfy-hocon/src/test/kotlin/tanvd/konfy/hocon/`
  - Implement tests for `HoconProvider` class
  - Test fetching values from the HOCON config
  - Create `config.conf` in `konfy-hocon/src/test/resources/` with sample configuration values for testing


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TanVD/konfy?shareId=c2ba22be-56cb-40b2-a805-423af8c8d892).