### PR TITLE
Add konfy-properties module with properties file support

### DIFF
--- a/konfy-properties/build.gradle.kts
+++ b/konfy-properties/build.gradle.kts
@@ -1,0 +1,21 @@
+group = rootProject.group
+version = rootProject.version
+
+dependencies {
+    api(project(":konfy"))
+
+    api("org.tomlj", "tomlj", "1.1.1")
+
+    testImplementation("org.assertj", "assertj-core", "3.24.2")
+    testImplementation("org.junit.jupiter", "junit-jupiter-api", "5.9.2")
+    testRuntimeOnly("org.junit.jupiter", "junit-jupiter-engine", "5.9.2")
+}
+
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}

--- a/konfy-properties/src/main/kotlin/tanvd/konfy/properties/PropertiesProvider.kt
+++ b/konfy-properties/src/main/kotlin/tanvd/konfy/properties/PropertiesProvider.kt
@@ -1,0 +1,33 @@
+package tanvd.konfy.properties
+
+import tanvd.konfy.conversion.ConversionService
+import tanvd.konfy.provider.ConfigProvider
+import tanvd.konfy.utils.toTypedArray
+import java.lang.reflect.Type
+import java.util.Properties
+
+class PropertiesProvider(private val properties: Properties) : ConfigProvider() {
+    override fun <N : Any> fetch(key: String, type: Type): N? {
+        val value = properties[key]?.toString() ?: return null
+        when {
+            (type is Class<*> && type.isArray) -> {
+                val values = value.split(",").map { it.trim() }
+                val converted = values.map { ConversionService.convert(it, type.componentType) }
+                return converted.toTypedArray(type.componentType) as N?
+            }
+
+            else -> {
+                val converted = ConversionService.convert(value, type)
+                return converted as N?
+            }
+        }
+    }
+
+    companion object {
+        fun from(value: String): PropertiesProvider {
+            val properties = Properties()
+            properties.load(value.byteInputStream())
+            return PropertiesProvider(properties)
+        }
+    }
+}

--- a/konfy-properties/src/main/kotlin/tanvd/konfy/properties/PropertiesProvider.kt
+++ b/konfy-properties/src/main/kotlin/tanvd/konfy/properties/PropertiesProvider.kt
@@ -1,29 +1,20 @@
 package tanvd.konfy.properties
 
-import tanvd.konfy.conversion.ConversionService
+import tanvd.konfy.properties.utils.Conversion
 import tanvd.konfy.provider.ConfigProvider
-import tanvd.konfy.utils.toTypedArray
 import java.lang.reflect.Type
-import java.util.Properties
+import java.util.*
 
 class PropertiesProvider(private val properties: Properties) : ConfigProvider() {
     override fun <N : Any> fetch(key: String, type: Type): N? {
         val value = properties[key]?.toString() ?: return null
-        when {
-            (type is Class<*> && type.isArray) -> {
-                val values = value.split(",").map { it.trim() }
-                val converted = values.map { ConversionService.convert(it, type.componentType) }
-                return converted.toTypedArray(type.componentType) as N?
-            }
-
-            else -> {
-                val converted = ConversionService.convert(value, type)
-                return converted as N?
-            }
-        }
+        return Conversion.convert(value, type) as N?
     }
 
     companion object {
+        /**
+         * Read properties from [value] string and return corresponding [PropertiesProvider]
+         */
         fun from(value: String): PropertiesProvider {
             val properties = Properties()
             properties.load(value.byteInputStream())

--- a/konfy-properties/src/main/kotlin/tanvd/konfy/properties/utils/Conversion.kt
+++ b/konfy-properties/src/main/kotlin/tanvd/konfy/properties/utils/Conversion.kt
@@ -1,0 +1,21 @@
+package tanvd.konfy.properties.utils
+
+import tanvd.konfy.conversion.ConversionService
+import tanvd.konfy.utils.toTypedArray
+import java.lang.reflect.Type
+
+object Conversion {
+    fun <N : Any> convert(value: String, type: Type): N? {
+        when {
+            (type is Class<*> && type.isArray) -> {
+                val values = value.split(",").map { it.trim() }
+                val converted = values.map { ConversionService.convert(it, type.componentType) }
+                return converted.toTypedArray(type.componentType) as N?
+            }
+
+            else -> {
+                return ConversionService.convert(value, type) as N?
+            }
+        }
+    }
+}

--- a/konfy-properties/src/test/kotlin/tanvd/konfy/properties/PropertiesConfigTest.kt
+++ b/konfy-properties/src/test/kotlin/tanvd/konfy/properties/PropertiesConfigTest.kt
@@ -1,0 +1,46 @@
+package tanvd.konfy.properties
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class PropertiesConfigTest {
+    private val configProvider
+        get() = PropertiesProvider.from(File("src/test/resources/config.properties").readText())
+
+    @Test
+    fun get_keyExists_gotValue() {
+        val value: String = configProvider.get("first_test")
+        assertThat(value).isEqualTo("test-pass")
+    }
+    
+    @Test
+    fun get_keyExists_gotIntValue() {
+        val value: Int = configProvider.get("second_test")
+        assertThat(value).isEqualTo(42)
+    }
+
+    @Test
+    fun tryGet_keyDoesNotExist_noValue() {
+        val value: String? = configProvider.tryGet("third_test")
+        assertThat(value).isNull()
+    }
+
+    @Test
+    fun get_keyInTable_gotValue() {
+        val value: String = configProvider.get("section.fourth_test")
+        assertThat(value).isEqualTo("test-pass")
+    }
+
+    @Test
+    fun get_arrayValue_gotValue() {
+        val value: Array<String> = configProvider.get("section.arena-letters")
+        assertThat(value).containsAll(listOf("All", "King", "Edwards", "Horses", "Can", "Move", "Bloody", "Fast"))
+    }
+    
+    @Test
+    fun get_valueWithSpaces_gotValue() {
+        val value: String = configProvider.get("section.nested.best-bike-ever")
+        assertThat(value).isEqualTo("KTM Duke 390")
+    }
+}

--- a/konfy-properties/src/test/resources/config.properties
+++ b/konfy-properties/src/test/resources/config.properties
@@ -1,0 +1,6 @@
+first_test = "test-pass"
+second_test = 42
+
+section.fourth_test = "test-pass"
+section.arena-letters = All,King,Edwards,Horses,Can,Move,Bloody,Fast
+section.nested.best-bike-ever = KTM Duke 390

--- a/konfy/src/main/kotlin/tanvd/konfy/utils/Conversion.kt
+++ b/konfy/src/main/kotlin/tanvd/konfy/utils/Conversion.kt
@@ -1,6 +1,6 @@
 package tanvd.konfy.utils
 
-internal fun Collection<*>.toTypedArray(type: Class<*>): Array<*> {
+fun Collection<*>.toTypedArray(type: Class<*>): Array<*> {
     @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     return (this as java.util.Collection<*>).toArray(java.lang.reflect.Array.newInstance(type, size) as Array<*>)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "konfy-root"
 
 include(":konfy")
 include(":konfy-toml")
+include(":konfy-properties")
 include(":konfy-keepass")
 include(":konfy-ssm")
 include(":konfy-kara")


### PR DESCRIPTION
Introduced a new konfy-properties module to handle configurations using properties files. Implemented PropertiesProvider and added tests for various scenarios, including value conversions and nested keys. Also, updated settings.gradle.kts to include the new module and made toTypedArray function public.